### PR TITLE
Flattened the hierarchy and ignored files

### DIFF
--- a/app/assets/stylesheets/.npmignore
+++ b/app/assets/stylesheets/.npmignore
@@ -1,0 +1,4 @@
+app/assets/stylesheets/site/
+app/assets/stylesheets/barebones.scss
+app/assets/stylesheets/application.scss
+app/assets/stylesheets/_custom_variables.scss

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   },
   "homepage": "https://github.com/yorthehunter/humblekit#readme",
   "files": [
-    "app/assets/stylesheets/**/*.scss"
+    "stylesheets"
   ]
 }

--- a/stylesheets
+++ b/stylesheets
@@ -1,0 +1,1 @@
+app/assets/stylesheets


### PR DESCRIPTION
To make the client usage a bit cleaner, the stylesheets are now
symlinked to the root of the project so the package.json can do away
with the `app/assets` nesting.

Also added an .npmignore to remove files that are specific to the rails
project humblekit is contained within.